### PR TITLE
added estimated product size after cube mitigation

### DIFF
--- a/weblogstats.py
+++ b/weblogstats.py
@@ -381,6 +381,7 @@ for run in runs:
       mitigatedcubesize = float(x[7].split()[-2])
       allowedprodsize   = float(x[9].split()[-2])
       initialprodsize   = float(x[11].split()[-2])
+      prodsizeaftercube = float(x[13].split()[-2])
       mitigatedprodsize = float(x[15].split()[-2])
 
       x=soup.table.tbody.find_all('tr')
@@ -430,6 +431,7 @@ for run in runs:
                      'mitigatedcubesize':mitigatedcubesize, 
                      'allowedprodsize'  :allowedprodsize  , 
                      'initialprodsize'  :initialprodsize  , 
+                     'prodsizeaftercube' :prodsizeaftercube , 
                      'mitigatedprodsize':mitigatedprodsize,
                      'mitigated': mitigated,
                      'mit_nbins': mit_nbins,


### PR DESCRIPTION
The original scraping code did not scrape the estimated produce size after cube mitigation. Scraping this value will allow us to separate cube only mitigations from cube plus productsize mitigations.